### PR TITLE
do no log invalid assets module when has urlPrefix

### DIFF
--- a/lib/url-builder.js
+++ b/lib/url-builder.js
@@ -35,7 +35,7 @@ class UrlBuilder {
       logger.error('can not resolve module: %s', route.module);
       return '';
     }
-    if (!info.assets) {
+    if (!info.assets && !this.urlPrefix) {
       logger.error('invalid assets module: %s', route.module);
       return '';
     }


### PR DESCRIPTION
当使用cdn时，prodction环境 中modules的assets中就没有资源代码了 